### PR TITLE
fix: Fixed the typo "All Rights Reserved"

### DIFF
--- a/Smartphone.html
+++ b/Smartphone.html
@@ -414,7 +414,7 @@
 
             </div>
             <div class="text-center m-2">
-                <strong>Code Shop</strong> &copy; <span id="copyRightYear"></span> All Right reserved
+                <strong>Code Shop</strong> &copy; <span id="copyRightYear"></span> All Rights Reserved
             </div>
         </div>
     </footer>

--- a/about/About.html
+++ b/about/About.html
@@ -457,7 +457,7 @@
                 
             </div>
             <div class="text-center m-2">
-                    <strong>Code Shop</strong> &copy; All Right reserved
+                    <strong>Code Shop</strong> &copy; All Rights Reserved
                 </div>
             </div>
         </footer>

--- a/index.html
+++ b/index.html
@@ -869,7 +869,7 @@
 
             </div>
             <div class="text-center m-2">
-                <strong>Code Shop</strong> &copy; <span id="copyRightYear"></span> All Right reserved
+                <strong>Code Shop</strong> &copy; <span id="copyRightYear"></span> All Rights Reserved
             </div>
         </div>
     </footer>

--- a/kids.html
+++ b/kids.html
@@ -398,7 +398,7 @@
 
             </div>
             <div class="text-center m-2">
-                <strong>Code Shop</strong> &copy; <span id="copyRightYear"></span> All Right reserved
+                <strong>Code Shop</strong> &copy; <span id="copyRightYear"></span> All Rights Reserved
             </div>
         </div>
     </footer>

--- a/menshirts.html
+++ b/menshirts.html
@@ -391,7 +391,7 @@
 
             </div>
             <div class="text-center m-2">
-                <strong>Code Shop</strong> &copy; <span id="copyRightYear"></span> All Right reserved
+                <strong>Code Shop</strong> &copy; <span id="copyRightYear"></span> All Rights Reserved
             </div>
         </div>
     </footer>

--- a/review.html
+++ b/review.html
@@ -317,7 +317,7 @@
 
             </div>
             <div class="text-center m-2">
-                <strong>Code Shop</strong> &copy; <span id="copyRightYear"></span> All Right reserved
+                <strong>Code Shop</strong> &copy; <span id="copyRightYear"></span> All Rights Reserved
             </div>
         </div>
     </footer>

--- a/womens.html
+++ b/womens.html
@@ -381,7 +381,7 @@
 
             </div>
             <div class="text-center m-2">
-                <strong>Code Shop</strong> &copy; <span id="copyRightYear"></span> All Right reserved
+                <strong>Code Shop</strong> &copy; <span id="copyRightYear"></span> All Rights Reserved
             </div>
         </div>
     </footer>


### PR DESCRIPTION
Fixes #156 

Corrected the typo in footer of all pages from **"All right reserved"** to **"All Rights Reserved"**